### PR TITLE
luv-test: Update plymouth command for hiding text

### DIFF
--- a/meta-luv/recipes-core/luv-test/luv-test/luv-message
+++ b/meta-luv/recipes-core/luv-test/luv-test/luv-message
@@ -8,7 +8,7 @@ luv_msg_write() {
 
     if [ $# == 2 ]; then
          sleep $2
-         plymouth_hide "$1"
+         /bin/plymouth hide-message --text="$1"
     fi
 
     echo "$1" >&2


### PR DESCRIPTION
luv_message_write was using unsupported
plymouth_hide command. Updated it to the correct
command as in luv_message_hide.

Signed-off-by: Sakar Arora <sakar.arora@arm.com>