### PR TITLE
Add symlink to LUV README from root

### DIFF
--- a/README.luv
+++ b/README.luv
@@ -1,0 +1,1 @@
+meta-luv/README


### PR DESCRIPTION
When unfamiliar with yocto/poky, it is unexpected to find the entry point of the LUV documentation in a sub-directory. This PR adds a symlink from the root to meta-luv/README, similarly to what is done with README.hardware or README.poky.

Signed-off-by: Thiébaud Weksteen <tweek@google.com>