### PR TITLE
bits: Add -no-pie flag to support Debian

### DIFF
--- a/meta-luv/recipes-bsp/bits/bits_git.bb
+++ b/meta-luv/recipes-bsp/bits/bits_git.bb
@@ -21,6 +21,7 @@ BBCLASSEXTEND = "native"
 # maintaining it, resolving all these warnings consumes a lot of time.
 # Thus, we have decided to not treat the warnings as errors.
 CFLAGS_append = " -Wno-error "
+LDFLAGS_append = " -no-pie "
 
 BITSVERSION="2079"
 PV="${BITSVERSION}+git${SRCPV}"


### PR DESCRIPTION
On Debian, ld has PIE enabled by default. This is similar to the
commit bc209d9b8dbfb842eb00f0a09e52025f1ca403ae for grub2.

Signed-off-by: Thiébaud Weksteen <tweek@google.com>